### PR TITLE
Add profile to compile shell to native executable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,40 @@
         </plugins>
       </build>
     </profile>
+    <!-- Shell App GraalVM Native Image Compilation Profile -->
+    <profile>
+      <id>shell-native</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.11.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <mainClass>dev.digiried.wattpilot.shell.App</mainClass>
+              <imageName>wattpilotShell</imageName>
+              <buildArgs>
+                <!-- enables additional compiler optimizations -->
+                <buildArg>-O3</buildArg>
+              </buildArgs>
+            </configuration>
+            <executions>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>compile-no-fork</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- Local GPG Signing Profile -->
     <profile>
       <id>local-sign</id>

--- a/src/main/java/dev/digiried/wattpilot/shell/App.java
+++ b/src/main/java/dev/digiried/wattpilot/shell/App.java
@@ -102,7 +102,9 @@ public class App implements WattpilotClientListener {
                     System.err.println("Invalid command: " + line);
                 }
             } else {
-                System.err.println("Unknown command: " + line);
+                if (!line.isEmpty()) {
+                    System.err.println("Unknown command: " + line);
+                }
             }
         }
         try {
@@ -136,7 +138,7 @@ wattpilot4j Shell - Copyright (c) 2025 Florian Hotze under Apache License, Versi
 Commands:
   status                                    get the current status of the wallbox
   set current <current>                     set the charging current in A [6-32]
-  set force <state>                         set the enforced charging state (ON, OFF, NONE)
+  set force <state>                         set the enforced charging state (ON, OFF, NEUTRAL)
   set mode <mode>                           set the charging mode (DEFAULT, ECO, NEXT_TRIP)
   set boost <enabled>                       enable/disable charging boost in ECO or NEXT_TRIP mode (true, false)
   set boost_soc_limit                       set the battery SoC limit in % for charging boost [0-100]

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,151 @@
+[
+  {
+    "name": "dev.digiried.wattpilot.dto.PartialStatus",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.AuthErrorMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.AuthMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.AuthRequiredMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.AuthSuccessMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.DeltaStatusMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.FullStatusMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.HelloMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.IncomingMessage",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.Message",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.MessageType",
+    "allDeclaredFields": true,
+    "fields": [
+      {
+        "name": "AUTH_ERROR"
+      },
+      {
+        "name": "AUTH_REQUIRED"
+      },
+      {
+        "name": "AUTH_SUCCESS"
+      },
+      {
+        "name": "DELTA_STATUS"
+      },
+      {
+        "name": "FULL_STATUS"
+      },
+      {
+        "name": "HELLO"
+      },
+      {
+        "name": "RESPONSE"
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.OutgoingMessage",
+    "allDeclaredFields": true
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.ResponseMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.SecuredMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "dev.digiried.wattpilot.messages.SetValueMessage",
+    "allDeclaredFields": true,
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Adds a new Maven profile `shell-native` that compiles the shell app into a native executable using GraalVM Native Image.
You therefore need GraalVM with Native Image installed.

Compile:

```shell
./mvnw -P shell-native clean package
```

Run:

```shell
./target/wattpilotShell hostOrIp password
```

For GH Action multi-platform build, see https://blogs.oracle.com/developers/post/building-cross-platform-native-images-with-graalvm.